### PR TITLE
Use https

### DIFF
--- a/orgmdb.el
+++ b/orgmdb.el
@@ -135,7 +135,7 @@ under the header."
 
 ;;;###autoload
 (defvar orgmdb-omdb-url
-  "http://www.omdbapi.com"
+  "https://www.omdbapi.com"
   "OMDb URL.")
 
 (defvar orgmdb-show-tag "series")


### PR DESCRIPTION
The endpoint supports it, and currently sends API key in plaintext